### PR TITLE
Handling exports where there are lots of potential users

### DIFF
--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -278,7 +278,8 @@ def main(argv=None):
 
                 if user_id not in USER_LIST.keys():
                     print "User ID %s not found in HipChat." % (user_id)
-                    return 2
+                    print "Using id rather than name for directory"
+                    USER_SUBSET[user_id] = user_id
                 else:
                     USER_SUBSET[user_id] = USER_LIST[user_id]
 


### PR DESCRIPTION
For orgs with > 100 users, the initial API call to map a user id to a username can fail to find the userid in the result set.  Rather than abandoning hope, just create the export files in a directory with the user id rather than the username.