### PR TITLE
Update api calls to return a maximum of 1000 results at a time

### DIFF
--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -124,7 +124,7 @@ def get_user_list(user_token):
     user_list = {}
 
     # Fetch the user list from the API
-    url = HIPCHAT_API_URL + "/user"
+    url = HIPCHAT_API_URL + "/user?max-results=1000"
     r = requests.get(url, headers=headers)
     TOTAL_REQUESTS += 1
 
@@ -176,7 +176,7 @@ def message_export(user_token, user_id, user_name):
 
     # Set initial URL with correct user_id
     global HIPCHAT_API_URL
-    url = HIPCHAT_API_URL + "/user/%s/history?date=%s&reverse=false" % (user_id, int(time()))
+    url = HIPCHAT_API_URL + "/user/%s/history?date=%s&reverse=false&max-results=1000" % (user_id, int(time()))
 
     # main loop to fetch and save messages
     while MORE_RECORDS:


### PR DESCRIPTION
HipChat's /v2/user and /v2/user/*/history endpoints allow returning a maximum of 1000 results at a time. Using this instead of the default will lead to much fewer API calls.

https://www.hipchat.com/docs/apiv2/method/get_all_users
https://www.hipchat.com/docs/apiv2/method/view_privatechat_history