### PR TITLE
handle pagination with max-results

### DIFF
--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -81,7 +81,7 @@ def log(msg):
         msg = msg[1:]
         log(' ')
     logit = '[%s] %s' % (datetime.now(), msg)
-    print(logit.encode('utf8'))
+    print(logit)
 
 
 def vlog(msg):
@@ -154,14 +154,6 @@ def message_export(user_token, user_id, user_name):
     # Set HTTP header to use user token for auth
     headers = {'Authorization': 'Bearer ' + user_token}
 
-    # create dirs for current user
-    dir_name = os.path.join(EXPORT_DIR, user_name)
-    if not os.path.isdir(dir_name):
-        os.makedirs(dir_name)
-    dir_name = os.path.join(FILE_DIR, user_id)
-    if not os.path.isdir(dir_name):
-        os.makedirs(dir_name)
-
     # flag to control pagination
     MORE_RECORDS = True
 
@@ -204,6 +196,18 @@ def message_export(user_token, user_id, user_name):
         # check JSON for objects and react
         if 'items' not in r.json():
             raise Usage("Could not find messages in API return data... Check your token and try again.")
+
+        if len(r.json().get('items')) == 0:
+            log("  No items for user %s, skipping" % user_name)
+            return
+
+        # create dirs for current user
+        dir_name = os.path.join(EXPORT_DIR, user_name)
+        if not os.path.isdir(dir_name):
+            os.makedirs(dir_name)
+        dir_name = os.path.join(FILE_DIR, user_id)
+        if not os.path.isdir(dir_name):
+            os.makedirs(dir_name)
 
         # write the current JSON dump to file
         file_name = os.path.join(EXPORT_DIR, user_name, str(LEVEL) + '.txt')
@@ -334,13 +338,15 @@ def main(argv=None):
         else:
             extract = USER_LIST.items()
 
+        total_users = len(extract)
+        current_user = 1
         for user_id, user_name in extract:
-            log("\nExporting 1-to-1 messages for %s (ID: %s)..." % (user_name, user_id))
+            log("\n[%s/%s] Exporting 1-to-1 messages for %s (ID: %s)..." % (current_user, total_users, user_name, user_id))
             try:
                 message_export(USER_TOKEN, user_id, user_name)
             except ApiError as e:
                 print("Hipchat API returned HTTP {code}/{type}: {message}".format(**e.message))
-                return
+            current_user += 1
 
     except Usage as err:
         print("%s: %s" % (sys.argv[0].split("/")[-1], str(err.msg)), file=sys.stderr)

--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -164,6 +164,9 @@ def message_export(user_token, user_id, user_name):
 
     # flag to control pagination
     MORE_RECORDS = True
+    START_INDEX = 0
+    MAX_RESULTS = 1000
+    START_TIME = int(time())
 
     # flag to track iteration through pages
     LEVEL = 0
@@ -176,7 +179,7 @@ def message_export(user_token, user_id, user_name):
 
     # Set initial URL with correct user_id
     global HIPCHAT_API_URL
-    url = HIPCHAT_API_URL + "/user/%s/history?date=%s&reverse=false&max-results=1000" % (user_id, int(time()))
+    url = HIPCHAT_API_URL + "/user/%s/history?date=%s&reverse=false&max-results=%s&start-index=%s" % (user_id, START_TIME, MAX_RESULTS, START_INDEX)
 
     # main loop to fetch and save messages
     while MORE_RECORDS:
@@ -239,11 +242,13 @@ def message_export(user_token, user_id, user_name):
                     check_requests_vs_limit()
 
         # check for more records to process
-        if 'next' in r.json()['links']:
-            url = r.json()['links']['next']
+        if len(r.json()["items"]) == MAX_RESULTS:
+            START_INDEX = START_INDEX + MAX_RESULTS
+            url = HIPCHAT_API_URL + "/user/%s/history?date=%s&reverse=false&max-results=%s&start-index=%s" % (user_id, START_TIME, MAX_RESULTS, START_INDEX)
             LEVEL += 1
         else:
             MORE_RECORDS = False
+            START_INDEX = 0
 
             # end loop
 

--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -74,7 +74,7 @@ FILE_DIR = os.path.join(EXPORT_DIR, 'uploads')
 HIPCHAT_API_URL = "http://api.hipchat.com/v2"
 REQUESTS_RATE_LIMIT = 100
 TOTAL_REQUESTS = 0
-
+COMPLETED_FILE = os.path.join(EXPORT_DIR, 'completed.txt')
 
 def log(msg):
     if msg[0] == "\n":
@@ -151,6 +151,12 @@ def display_userlist(user_list):
 
 
 def message_export(user_token, user_id, user_name):
+
+    # Return if user has already been exported
+    if os.path.isfile(COMPLETED_FILE) and user_id in io.open(COMPLETED_FILE).read():
+        log("  User already exported")
+        return
+
     # Set HTTP header to use user token for auth
     headers = {'Authorization': 'Bearer ' + user_token}
 
@@ -206,6 +212,8 @@ def message_export(user_token, user_id, user_name):
 
         if len(r.json().get('items')) == 0:
             log("  No items for user %s, skipping" % user_name)
+            with io.open(COMPLETED_FILE, 'a', encoding='utf-8') as f:
+                f.write("%s %s - 0 messages\n" % (user_id, user_name))
             return
 
         # create dirs for current user
@@ -260,6 +268,8 @@ def message_export(user_token, user_id, user_name):
 
             # end loop
 
+    with io.open(COMPLETED_FILE, 'a', encoding='utf-8') as f:
+        f.write("%s %s\n" % (user_id, user_name))
 
 class Usage(Exception):
     def __init__(self, msg):

--- a/hipchat-export.py
+++ b/hipchat-export.py
@@ -164,8 +164,12 @@ def message_export(user_token, user_id, user_name):
 
     # flag to control pagination
     MORE_RECORDS = True
+
+    # pagination variables
     START_INDEX = 0
     MAX_RESULTS = 1000
+
+    # start time
     START_TIME = int(time())
 
     # flag to track iteration through pages
@@ -340,12 +344,12 @@ def main(argv=None):
             extract = USER_LIST.items()
 
         for user_id, user_name in extract:
-            log("\nExporting 1-to-1 messages for %s (ID: %s)..." % (user_name, user_id))
-            try:
-                message_export(USER_TOKEN, user_id, user_name)
-            except ApiError as e:
-                print("Hipchat API returned HTTP {code}/{type}: {message}".format(**e.message))
-                return
+            for user_id, user_name in extract:
+                log("\nExporting 1-to-1 messages for %s (ID: %s)..." % (user_name, user_id))
+                try:
+                    message_export(USER_TOKEN, user_id, user_name)
+                except ApiError as e:
+                    print("Hipchat API returned HTTP {code}/{type}: {message}".format(**e.message))
 
     except Usage as err:
         print("%s: %s" % (sys.argv[0].split("/")[-1], str(err.msg)), file=sys.stderr)


### PR DESCRIPTION
After the previous change to max-results=1000 the Hipchat API stopped returning a "next" link in the message response. This handles pagination based on how many results are returned.